### PR TITLE
remove plugins and ignore folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+platforms/
+plugins/
+package-lock.json

--- a/config.xml
+++ b/config.xml
@@ -7,10 +7,7 @@
     <author email="contato@fabricadeplugins.com.br" href="https://www.fabricadeplugins.com.br/">
         Fabrica de Plugins e Diogenes Junior
     </author>
-
     <engine name="android" spec="^13.0.0" />
-    
-    <!--<preference name="android-build-tool" value="gradle" />-->
     <preference name="orientation" value="portrait" />
     <preference name="target-device" value="handset" />
     <preference name="fullscreen" value="false" />
@@ -23,30 +20,17 @@
     <preference name="disable-cursor" value="false" />
     <preference name="android-installLocation" value="auto" />
     <preference name="StatusBarBackgroundColor" value="#00940a" />
-
     <preference name="AutoHideSplashScreen" value="true" />
     <preference name="SplashScreen" value="none" />
     <preference name="ShowSplashScreen" value="false" />
-
     <preference name="android-minSdkVersion" value="29" />
     <preference name="android-targetSdkVersion" value="34" />
     <preference name="android-compileSdkVersion" value="34" />
-
     <preference name="AndroidXEnabled" value="true" />
-
-    <edit-config file="AndroidManifest.xml" mode="merge" target="/manifest/application/activity[@android:name='MainActivity']">
-        <activity android:exported="true" />
-    </edit-config>
-
-    <plugin name="cordova-plugin-androidx" />
-    <plugin name="cordova-plugin-androidx-adapter" />
-    <!--<plugin name="cordova-plugin-local-notification" />-->
     <plugin name="cordova-plugin-android-permissions" />
     <plugin name="cordova-plugin-inappbrowser" />
     <plugin name="cordova-plugin-statusbar" />
     <plugin name="cordova-plugin-ionic-webview" />
-   
-
     <preference name="WKWebViewOnly" value="true" />
     <feature name="CDVWKWebViewEngine">
         <param name="ios-package" value="CDVWKWebViewEngine" />
@@ -54,13 +38,8 @@
     <preference name="CordovaWebViewEngine" value="CDVWKWebViewEngine" />
     <preference name="Scheme" value="https" />
     <preference name="ScrollEnabled" value="true" />
-
     <platform name="android">
-
         <preference name="android-minSdkVersion" value="29" />
-        <preference name="android-targetSdkVersion" value="33" />
-        <preference name="android-compileSdkVersion" value="33" />
-
         <icon density="ldpi" height="36" src="www/assets/images/icones/36.png" width="36" />
         <icon density="ldpi" height="40" src="www/assets/images/icones/40.png" width="40" />
         <icon density="mdpi" height="57" src="www/assets/images/icones/57.png" width="57" />
@@ -80,8 +59,7 @@
         <icon density="xxxhdpi" height="768" src="www/assets/images/icones/768.png" width="768" />
         <icon density="xxxhdpi" height="960" src="www/assets/images/icones/960.png" width="960" />
         <icon density="xxxhdpi" height="1024" src="www/assets/images/icones/1024x1024.png" width="1024" />
-
-        <plugin name="cordova-plugin-whitelist" version="1.3.4"  />
+        <plugin name="cordova-plugin-whitelist" version="1.3.4" />
         <access origin="*" />
         <allow-navigation href="*" />
         <allow-intent href="*" />
@@ -91,7 +69,6 @@
         <allow-intent href="sms:*" />
         <allow-intent href="mailto:*" />
         <allow-intent href="geo:*" />
-    
     </platform>
     <platform name="ios">
         <icon density="ldpi" height="36" src="www/assets/images/icones/36.png" width="36" />
@@ -122,6 +99,4 @@
         <icon height="152" src="www/assets/images/icones/152.png" width="152" />
         <icon height="167" src="www/assets/images/icones/167.png" width="167" />
     </platform>
-
-    
 </widget>

--- a/package.json
+++ b/package.json
@@ -19,5 +19,19 @@
   "bugs": {
     "url": "https://github.com/diogenesjup/pesuas/issues"
   },
-  "homepage": "https://github.com/diogenesjup/pesuas#readme"
+  "homepage": "https://github.com/diogenesjup/pesuas#readme",
+  "devDependencies": {
+    "cordova-android": "^13.0.0"
+  },
+  "cordova": {
+    "platforms": [
+      "android"
+    ],
+    "plugins": {
+      "cordova-plugin-android-permissions": {},
+      "cordova-plugin-inappbrowser": {},
+      "cordova-plugin-statusbar": {},
+      "cordova-plugin-ionic-webview": {}
+    }
+  }
 }


### PR DESCRIPTION
Removed cordova-plugin-androidx and cordova-plugin-androidx-adapter

 Removed the exported true since that's added by cordova-android now
```
<edit-config file="AndroidManifest.xml" mode="merge" target="/manifest/application/activity[@android:name='MainActivity']">
        <activity android:exported="true" />
</edit-config>
```
Removed duplicated preferences since there were others setting the value to 34
```
<preference name="android-targetSdkVersion" value="33" />
<preference name="android-compileSdkVersion" value="33" />
```

With this changes, the app builds on appflow fine